### PR TITLE
feat: 대용량 파일 업로드 시 aws s3 multipart upload를 활용한 업로드 기능 추가

### DIFF
--- a/src/main/java/re/kr/icuh/icuhplatform/controller/AttachmentApiController.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/controller/AttachmentApiController.java
@@ -1,19 +1,26 @@
 package re.kr.icuh.icuhplatform.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import re.kr.icuh.icuhplatform.service.AttachmentService;
+import re.kr.icuh.icuhplatform.util.AttachmentStore;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class AttachmentApiController {
 
     private final AttachmentService attachmentService;
+    private final AttachmentStore attachmentStore;
 
     @GetMapping("/test")
     public String test() {
@@ -26,5 +33,30 @@ public class AttachmentApiController {
         attachmentService.createAttachment(file);
 
         return "ok";
+    }
+
+    @PostMapping("/large-attachment")
+    public ResponseEntity<String> largeAttachments(@RequestParam("attachment") MultipartFile multipartFile) throws Exception {
+
+        try {
+            // MultipartFile을 임시 File로 변환
+            File file = File.createTempFile("temp_", multipartFile.getOriginalFilename());
+            multipartFile.transferTo(file);
+
+            // S3에 Multipart Upload 실행
+            String fileUrl = attachmentStore.uploadLargeAttachment(file);
+
+            // 임시 파일 삭제
+            if (!file.delete()) {
+                log.warn("임시 파일 삭제 실패: {}", file.getPath());
+            }
+
+            return ResponseEntity.ok(fileUrl);
+
+        } catch (Exception e) {
+            log.error("파일 업로드 실패", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("파일 업로드 중 오류가 발생했습니다.");
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #11 

## 개요
- 대용량 파일 업로드 시 건당 1분 이상의 시간이 소요되는 문제

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - 기존에 대용량 파일 업로드에 대한 요청 시 건당 1분 이상의 시간이 소요되었음

- **to-be**(변경 후 설명을 여기에 작성)
- 클라이언트 사이드 측에서 1MB 단위로 파일을 쪼개서 전송한 뒤, 서버 측에서 이를 재조립하여 S3로 업로드하는 방식으로 최초 개발했으나, 파일을 재조립하는 과정에서 문제가 발생하였음
- 이 후 AWS S3 MultiPart Upload 방식을 사용하여 직접 클라이언트, 서버 측에서 파일을 쪼개는 것이 아니라 해당 방식을 제공받는 형태로 변경함

## 체크리스트
- [ ] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)
