### PR TITLE
Feat/#21/create article

### DIFF
--- a/src/main/java/re/kr/icuh/icuhplatform/controller/FileStorageController.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/controller/FileStorageController.java
@@ -1,14 +1,14 @@
 package re.kr.icuh.icuhplatform.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.tomcat.util.http.fileupload.FileUpload;
-import org.apache.tomcat.util.http.fileupload.FileUploadException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import re.kr.icuh.icuhplatform.service.FileStorageService;
+import re.kr.icuh.icuhplatform.dto.article.CreateArticleRequest;
+import re.kr.icuh.icuhplatform.service.ArticleService;
 
 import java.io.IOException;
 import java.util.List;
@@ -19,27 +19,14 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FileStorageController {
 
-    private final FileStorageService fileStorageService;
+    private final ArticleService articleService;
 
-    @GetMapping("/test")
-    @ResponseStatus(value = HttpStatus.OK)
-    public String test() {
-        return "<h1> 안녕하세요 가뭄 정보 빅데이터 플랫폼에 오신 것을 환영합니다. </h1>";
-    }
-
-    @PostMapping("/attachments")
+    @PostMapping("/articles")
     @ResponseStatus(value = HttpStatus.CREATED)
-    public ResponseEntity<String> attachments(@RequestPart("attachment") List<MultipartFile> file) throws IOException {
-        fileStorageService.createAttachment(file);
+    public ResponseEntity<String> createArticle(@RequestPart @Valid CreateArticleRequest request, @RequestPart List<MultipartFile> files) throws IOException {
+
+        articleService.createArticle(request, files);
 
         return ResponseEntity.ok("파일 업로드 성공");
-    }
-
-    @PostMapping("/large-attachment")
-    @ResponseStatus(value = HttpStatus.CREATED)
-    public ResponseEntity<String> largeAttachments(@RequestParam("attachment") MultipartFile multipartFile) throws Exception {
-        fileStorageService.uploadLargeFile(multipartFile);
-
-        return ResponseEntity.ok("대용량 파일 업로드 성공");
     }
 }

--- a/src/main/java/re/kr/icuh/icuhplatform/domain/Article.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/domain/Article.java
@@ -1,16 +1,17 @@
 package re.kr.icuh.icuhplatform.domain;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.testcontainers.shaded.com.google.common.hash.Hashing;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import static re.kr.icuh.icuhplatform.domain.Article.ArticleStatus.ACTIVE;
 
 @Entity
 @Table(name = "articles")
@@ -66,6 +67,24 @@ public class Article {
 
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FileEntity> files = new ArrayList<>();
+
+    @Builder
+    public Article(String title, String description, String author, String authorOrganization, String department, String tempPassword, Integer views, ArticleStatus status, Classification classification, ServiceType serviceType) {
+        this.title = title;
+        this.description = description;
+        this.author = author;
+        this.authorOrganization = authorOrganization;
+        this.department = department;
+        this.tempPassword = sha256Encode(tempPassword);
+        this.views = views == null ? 0 : views;
+        this.status = status == null ? ACTIVE : status;
+        this.classification = classification;
+        this.serviceType = serviceType;
+    }
+
+    public String sha256Encode(String tempPassword) {
+        return Hashing.sha256().hashString(tempPassword, StandardCharsets.UTF_8).toString();
+    }
 
     // 소프트 삭제 메서드
     public void softDelete() {

--- a/src/main/java/re/kr/icuh/icuhplatform/domain/FileEntity.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/domain/FileEntity.java
@@ -2,7 +2,7 @@ package re.kr.icuh.icuhplatform.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 @Table(name = "files")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class FileEntity {
 
     @Id
@@ -24,20 +23,20 @@ public class FileEntity {
     @JoinColumn(name = "article_id", nullable = false)
     private Article article;
 
-    @Column(nullable = false, length = 255, name = "original_filename")
+    @Column(name = "original_filename")
     private String originalFilename;
 
-    @Column(nullable = false, length = 255, name = "stored_filename")
+    @Column(name = "stored_filename")
     private String storedFilename;
 
-    @Column(nullable = false, length = 512, name = "file_path")
+    @Column(name = "file_path")
     private String filePath;
 
     @Column(name = "file_size")
     private Long fileSize;
 
     @CreationTimestamp
-    @Column(nullable = false, updatable = false, name = "created_at")
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
 
     @Enumerated(EnumType.STRING)
@@ -47,6 +46,17 @@ public class FileEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "extension_id", nullable = false)
     private Extension extension;
+
+    @Builder
+    public FileEntity(Article article, String originalFilename, String storedFilename, String filePath, Long fileSize, Extension extension) {
+        this.article = article;
+        this.originalFilename = originalFilename;
+        this.storedFilename = storedFilename;
+        this.filePath = filePath;
+        this.fileSize = fileSize;
+        this.status = FileStatus.ACTIVE;
+        this.extension = extension;
+    }
 
     // 소프트 삭제 메서드
     public void softDelete() {

--- a/src/main/java/re/kr/icuh/icuhplatform/domain/FileMetadata.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/domain/FileMetadata.java
@@ -12,12 +12,12 @@ public class FileMetadata {
     private String originalName;    // 원본 파일명
     private String savedName;       // 저장된 파일명 (UUID)
     private String extensionName;   // 파일 확장자
-    private Integer size;           // 파일 크기
+    private Long size;           // 파일 크기
     private String contentType;     // 파일 타입 (MIME type)
 
     @Builder
     public FileMetadata(String originalName, String savedName,
-                        String extensionName, Integer size, String contentType) {
+                        String extensionName, Long size, String contentType) {
         this.originalName = originalName;
         this.savedName = savedName;
         this.extensionName = extensionName;

--- a/src/main/java/re/kr/icuh/icuhplatform/domain/ServiceType.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/domain/ServiceType.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "service_type")
+@Table(name = "service_types")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/re/kr/icuh/icuhplatform/dto/article/CreateArticleRequest.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/dto/article/CreateArticleRequest.java
@@ -1,12 +1,14 @@
 package re.kr.icuh.icuhplatform.dto.article;
 
+import jakarta.validation.constraints.NotNull;
+
 public record CreateArticleRequest(
-        String title,
-        String description,
-        String author,
-        String authorOrganization,
-        String department,
-        String tempPassword,
-        Long classificationId,
-        Long serviceTypeId
+        @NotNull String title,
+        @NotNull String description,
+        @NotNull String author,
+        @NotNull String authorOrganization,
+        @NotNull String department,
+        @NotNull String tempPassword,
+        @NotNull Long classificationId,
+        @NotNull Long serviceTypeId
 ) {}

--- a/src/main/java/re/kr/icuh/icuhplatform/global/exception/ErrorCode.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/global/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
 	 */
 	INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "유효하지 않은 입력값입니다."),
 	MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "MISSING_REQUIRED_FIELD", "필수 필드가 누락되었습니다."),
-
+	CLASSIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "CLASSIFICATION_NOT_FOUND", "분류체계가 아닙니다."),
+	SERVICE_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "SERVICE_TYPE_NOT_FOUND", "서비스 타입이 아닙니다."),
 	/**
 	 * 401 Unauthorized
 	 */

--- a/src/main/java/re/kr/icuh/icuhplatform/global/util/FileUtils.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/global/util/FileUtils.java
@@ -32,11 +32,11 @@ public class FileUtils {
     /**
      * 파일 크기를 Integer로 변환합니다.
      */
-    public Integer convertToIntegerSize(long size) {
+    public Long convertToIntegerSize(long size) {
         if (size > Integer.MAX_VALUE) {
             throw new IllegalArgumentException("File size is too large to convert to Integer");
         }
-        return Long.valueOf(size).intValue();
+        return size;
     }
 
     /**

--- a/src/main/java/re/kr/icuh/icuhplatform/repository/ExtensionRepository.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/repository/ExtensionRepository.java
@@ -4,6 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import re.kr.icuh.icuhplatform.domain.Extension;
 
+import java.util.Optional;
+
 @Repository
 public interface ExtensionRepository extends JpaRepository<Extension, Long> {
+
+    Optional<Extension> findByName(String name);
 }

--- a/src/main/java/re/kr/icuh/icuhplatform/service/ArticleService.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/service/ArticleService.java
@@ -1,0 +1,75 @@
+package re.kr.icuh.icuhplatform.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import re.kr.icuh.icuhplatform.domain.Article;
+import re.kr.icuh.icuhplatform.domain.Classification;
+import re.kr.icuh.icuhplatform.domain.ServiceType;
+import re.kr.icuh.icuhplatform.dto.article.CreateArticleRequest;
+import re.kr.icuh.icuhplatform.global.exception.BusinessException;
+import re.kr.icuh.icuhplatform.global.exception.ErrorCode;
+import re.kr.icuh.icuhplatform.repository.ArticleRepository;
+import re.kr.icuh.icuhplatform.repository.ClassificationRepository;
+import re.kr.icuh.icuhplatform.repository.ServiceTypeRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleService {
+
+    /**
+     * 1. CreateArticleRequest가 넘어온다.
+     * 2. CreateArticleReqeust 안에 Article과 List<Multipart> files에 대한 유효성 검사를 진행한다.
+     * 3. files 유효성이 끝나면 s3를 통해 업로드 된다.
+     * 3-1. S3 업로드 실패가 된다면 전부 rollback
+     * 4. 3번 스텝이 끝나면 files -> 변환 -> fileEntity DB에 저장, CreateArticle -> 변환 -> article DB에 저장
+     */
+
+    private final ArticleRepository articleRepository;
+    private final FileStorageService fileStorageService;
+    private final ClassificationRepository classificationRepository;
+    private final ServiceTypeRepository serviceTypeRepository;
+
+    public void createArticle(CreateArticleRequest request, List<MultipartFile> files) {
+        validateFiles(files);
+
+        Classification classification = classificationRepository.findById(request.classificationId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLASSIFICATION_NOT_FOUND));
+
+        ServiceType serviceType = serviceTypeRepository.findById(request.serviceTypeId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.SERVICE_TYPE_NOT_FOUND));
+
+
+        Article article = Article.builder()
+                .title(request.title())
+                .description(request.description())
+                .author(request.author())
+                .authorOrganization(request.authorOrganization())
+                .department(request.department())
+                .tempPassword(request.tempPassword())
+                .views(0)
+                .status(Article.ArticleStatus.ACTIVE)
+                .classification(classification)
+                .serviceType(serviceType)
+                .build();
+
+        Article savedArticle = articleRepository.save(article);
+
+        fileStorageService.uploadLargeFiles(files, savedArticle);
+    }
+
+
+    private void validateFiles(List<MultipartFile> files) {
+        for (MultipartFile file : files) {
+            if (file == null || file.isEmpty()) {
+                throw new BusinessException(ErrorCode.FILE_NOT_FOUND);
+            }
+
+            if (file.getOriginalFilename().endsWith(".exe") || file.getOriginalFilename().endsWith(".dmg")) {
+                throw new BusinessException(ErrorCode.UNSUPPORTED_FILE_TYPE);
+            }
+        }
+    }
+}

--- a/src/main/java/re/kr/icuh/icuhplatform/service/FileStorageService.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/service/FileStorageService.java
@@ -6,12 +6,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import re.kr.icuh.icuhplatform.domain.Attachment;
-import re.kr.icuh.icuhplatform.domain.FileMetadata;
+import re.kr.icuh.icuhplatform.domain.*;
 import re.kr.icuh.icuhplatform.dto.CreateAttachmentDto;
 import re.kr.icuh.icuhplatform.global.exception.BusinessException;
 import re.kr.icuh.icuhplatform.global.exception.ErrorCode;
 import re.kr.icuh.icuhplatform.global.util.FileUtils;
+import re.kr.icuh.icuhplatform.repository.ExtensionRepository;
+import re.kr.icuh.icuhplatform.repository.FileRepository;
 import re.kr.icuh.icuhplatform.repository.FileStorageRepository;
 
 import java.io.File;
@@ -26,8 +27,11 @@ public class FileStorageService {
     private final FileUtils fileUtils;
     private final S3FileUploader s3FileUploader;
     private final FileStorageRepository fileStorageRepository;
+    private final FileRepository fileRepository;
+    private final ExtensionRepository extensionRepository;
 
-    public void createAttachment(List<MultipartFile> file) throws IOException {
+
+    public void createFile(List<MultipartFile> file) throws IOException {
 
         for (MultipartFile multipartFile : file) {
             validateNull(multipartFile);
@@ -42,17 +46,20 @@ public class FileStorageService {
         }
     }
 
-    public void uploadLargeFile(MultipartFile multipartFile) {
-        validateNull(multipartFile);
-        validateExtension(multipartFile);
+    public void uploadLargeFiles(List<MultipartFile> files, Article article) {
+        for (MultipartFile file : files) {
+            uploadLargeFile(file, article);
+        }
+    }
 
+    private void uploadLargeFile(MultipartFile multipartFile, Article article) {
         File tempFile = null;
 
         try {
             tempFile = convertToTempFile(multipartFile);
             FileMetadata metadata = createFileMetadata(multipartFile);
             String fileUrl = uploadToS3(tempFile);
-            saveFileMetadata(metadata, fileUrl);
+            saveFileMetadataToFileEntity(metadata, fileUrl, article);
         } catch (Exception e) {
             throw new BusinessException(ErrorCode.FILE_SIZE_EXCEEDED, e.getMessage());
         } finally {
@@ -86,17 +93,22 @@ public class FileStorageService {
         }
     }
 
-    private void saveFileMetadata(FileMetadata fileMetadata, String fileUrl) {
-        CreateAttachmentDto dto = CreateAttachmentDto.builder()
-            .originalName(fileMetadata.getOriginalName())
-            .savedPath(fileUrl)
-            .savedName(fileMetadata.getSavedName())
-            .extensionName(fileMetadata.getExtensionName())
-            .size(fileMetadata.getSize())
-            .build();
+    private void saveFileMetadataToFileEntity(FileMetadata fileMetadata, String fileUrl, Article article) {
 
-        Attachment attachment = dto.toAttachment(dto);
-        fileStorageRepository.save(attachment);
+        // Extension 가져오기
+        Extension extension = extensionRepository.findByName(fileMetadata.getExtensionName())
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNSUPPORTED_FILE_TYPE));
+
+        FileEntity fileEntity = FileEntity.builder()
+                .article(article)
+                .originalFilename(fileMetadata.getOriginalName())
+                .storedFilename(fileMetadata.getSavedName())
+                .filePath(fileUrl)
+                .fileSize(fileMetadata.getSize())
+                .extension(extension)
+                .build();
+
+        fileRepository.save(fileEntity);
     }
 
     private void validateNull(MultipartFile multipartFile) {

--- a/src/main/java/re/kr/icuh/icuhplatform/service/S3FileUploader.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/service/S3FileUploader.java
@@ -7,9 +7,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
-import re.kr.icuh.icuhplatform.global.util.FileUtils;
 import re.kr.icuh.icuhplatform.domain.FileMetadata;
 import re.kr.icuh.icuhplatform.dto.CreateAttachmentDto;
+import re.kr.icuh.icuhplatform.global.util.FileUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -57,7 +57,6 @@ public class S3FileUploader {
                 .savedPath(savedPath)
                 .savedName(metadata.getSavedName())
                 .extensionName(metadata.getExtensionName())
-                .size(metadata.getSize())
                 .build();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #21 

## 개요
게시글 API 명세서에 맞춰서 게시글 생성 기능 추가

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
대용량 파일만 업로드 되었음

- **to-be**(변경 후 설명을 여기에 작성)
게시글 본문과 대용량 파일 업로드

  - [x] 유효값 검증
  - [x] 게시글 생성
  - [] 예외처리


## 코멘트
- 파일명이 긴 경우에는, DB 컬럼의 제약조건으로 인해 업로드 해당 정보가 insert 되지 않음, 제약조건을 변경해도 되지만 그것보다 다른 방법을 먼저 생각해봐야함
- 업로드 과정에서 정의한 예외상황말고 다른 상황들이 종종 발생하는데 이에 대한 내용도 별도로 정의가 필요함
