### PR TITLE
[refactor] 불필요한 로직 제거 및 리펙토링

### DIFF
--- a/src/main/java/re/kr/icuh/icuhplatform/global/util/FileUtils.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/global/util/FileUtils.java
@@ -16,9 +16,8 @@ public class FileUtils {
      * UUID를 사용하여 고유한 파일명을 생성합니다.
      */
     public String createStoreFileName(String originName) {
-        String extensionName = extractExtensionName(originName);
         String uuid = UUID.randomUUID().toString();
-        return uuid + "." + extensionName;
+        return uuid + "_" + originName;
     }
 
     /**

--- a/src/main/java/re/kr/icuh/icuhplatform/service/ArticleService.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/service/ArticleService.java
@@ -27,8 +27,8 @@ public class ArticleService {
      * 4. 3번 스텝이 끝나면 files -> 변환 -> fileEntity DB에 저장, CreateArticle -> 변환 -> article DB에 저장
      */
 
-    private final ArticleRepository articleRepository;
     private final FileStorageService fileStorageService;
+    private final ArticleRepository articleRepository;
     private final ClassificationRepository classificationRepository;
     private final ServiceTypeRepository serviceTypeRepository;
 

--- a/src/main/java/re/kr/icuh/icuhplatform/service/FileStorageService.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/service/FileStorageService.java
@@ -1,23 +1,20 @@
 package re.kr.icuh.icuhplatform.service;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.SdkClientException;
+import java.io.File;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import re.kr.icuh.icuhplatform.domain.*;
-import re.kr.icuh.icuhplatform.dto.CreateAttachmentDto;
+import re.kr.icuh.icuhplatform.domain.Article;
+import re.kr.icuh.icuhplatform.domain.Extension;
+import re.kr.icuh.icuhplatform.domain.FileEntity;
+import re.kr.icuh.icuhplatform.domain.FileMetadata;
 import re.kr.icuh.icuhplatform.global.exception.BusinessException;
 import re.kr.icuh.icuhplatform.global.exception.ErrorCode;
 import re.kr.icuh.icuhplatform.global.util.FileUtils;
 import re.kr.icuh.icuhplatform.repository.ExtensionRepository;
 import re.kr.icuh.icuhplatform.repository.FileRepository;
-import re.kr.icuh.icuhplatform.repository.FileStorageRepository;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
 
 @Slf4j
 @Service
@@ -26,25 +23,9 @@ public class FileStorageService {
 
     private final FileUtils fileUtils;
     private final S3FileUploader s3FileUploader;
-    private final FileStorageRepository fileStorageRepository;
     private final FileRepository fileRepository;
     private final ExtensionRepository extensionRepository;
 
-
-    public void createFile(List<MultipartFile> file) throws IOException {
-
-        for (MultipartFile multipartFile : file) {
-            validateNull(multipartFile);
-            validateExtension(multipartFile);
-        }
-
-        List<CreateAttachmentDto> attachmentDtos = s3FileUploader.storeAttachments(file);
-
-        for (CreateAttachmentDto attachmentDto : attachmentDtos) {
-            Attachment attachment = attachmentDto.toAttachment(attachmentDto);
-            fileStorageRepository.save(attachment);
-        }
-    }
 
     public void uploadLargeFiles(List<MultipartFile> files, Article article) {
         for (MultipartFile file : files) {
@@ -56,9 +37,10 @@ public class FileStorageService {
         File tempFile = null;
 
         try {
-            tempFile = convertToTempFile(multipartFile);
-            FileMetadata metadata = createFileMetadata(multipartFile);
-            String fileUrl = uploadToS3(tempFile);
+            FileMetadata metadata = fileUtils.createFileMetadata(multipartFile);
+            tempFile = fileUtils.convertToTempFile(multipartFile);
+
+            String fileUrl = s3FileUploader.uploadLargeAttachment(tempFile, metadata.getSavedName());
             saveFileMetadataToFileEntity(metadata, fileUrl, article);
         } catch (Exception e) {
             throw new BusinessException(ErrorCode.FILE_SIZE_EXCEEDED, e.getMessage());
@@ -67,31 +49,6 @@ public class FileStorageService {
         }
     }
 
-    private File convertToTempFile(MultipartFile multipartFile) {
-        try {
-            return fileUtils.convertToTempFile(multipartFile);
-        } catch (IOException | RuntimeException e) {
-            throw new BusinessException(ErrorCode.UNSUPPORTED_FILE_TYPE, e.getMessage());
-        }
-    }
-
-    private FileMetadata createFileMetadata(MultipartFile multipartFile) {
-        try {
-            return fileUtils.createFileMetadata(multipartFile);
-        } catch (IllegalArgumentException e) {
-            throw new BusinessException(ErrorCode.UNSUPPORTED_FILE_TYPE, e.getMessage());
-        }
-    }
-
-    private String uploadToS3(File tempFile) {
-        try {
-            return s3FileUploader.uploadLargeAttachment(tempFile);
-        } catch (AmazonServiceException ase) {
-            throw new BusinessException(ErrorCode.UNSUPPORTED_FILE_TYPE, ase.getMessage());
-        } catch (SdkClientException sce) {
-            throw new BusinessException(ErrorCode.UNSUPPORTED_FILE_TYPE, sce.getMessage());
-        }
-    }
 
     private void saveFileMetadataToFileEntity(FileMetadata fileMetadata, String fileUrl, Article article) {
 
@@ -111,15 +68,4 @@ public class FileStorageService {
         fileRepository.save(fileEntity);
     }
 
-    private void validateNull(MultipartFile multipartFile) {
-        if (multipartFile == null || multipartFile.isEmpty()) {
-            throw new BusinessException(ErrorCode.FILE_NOT_FOUND);
-        }
-    }
-
-    private void validateExtension(MultipartFile multipartFile) {
-        if (multipartFile.getOriginalFilename().endsWith(".exe") || multipartFile.getOriginalFilename().endsWith(".dmg")) {
-            throw new BusinessException(ErrorCode.UNSUPPORTED_FILE_TYPE);
-        }
-    }
 }

--- a/src/main/java/re/kr/icuh/icuhplatform/service/S3FileUploader.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/service/S3FileUploader.java
@@ -60,12 +60,9 @@ public class S3FileUploader {
                 .build();
     }
 
-    public String uploadLargeAttachment(File file) {
-
-        String fileName = createFileName(file.getName());
-
+    public String uploadLargeAttachment(File file, String savedName) throws IOException {
         // 1단계: Multipart Upload 초기화
-        InitiateMultipartUploadRequest initiateRequest = new InitiateMultipartUploadRequest(bucket, fileName)
+        InitiateMultipartUploadRequest initiateRequest = new InitiateMultipartUploadRequest(bucket, savedName)
                 .withCannedACL(CannedAccessControlList.PublicRead);
 
         InitiateMultipartUploadResult initResult = amazonS3Client.initiateMultipartUpload(initiateRequest);
@@ -90,7 +87,7 @@ public class S3FileUploader {
 
                     UploadPartRequest uploadRequest = new UploadPartRequest()
                             .withBucketName(bucket)
-                            .withKey(fileName)
+                            .withKey(savedName)
                             .withUploadId(uploadId)
                             .withPartNumber(partNumber)
                             .withInputStream(inputStream)
@@ -109,14 +106,14 @@ public class S3FileUploader {
             // 3단계: Multipart Upload 완료
             CompleteMultipartUploadRequest completeRequest = new CompleteMultipartUploadRequest(
                     bucket,
-                    fileName,
+                    savedName,
                     uploadId,
                     partETags
             );
 
             amazonS3Client.completeMultipartUpload(completeRequest);
 
-            String fileUrl = amazonS3Client.getUrl(bucket, fileName).toString();
+            String fileUrl = amazonS3Client.getUrl(bucket, savedName).toString();
             log.info("Multipart Upload 완료 - URL: {}", fileUrl);
 
             return fileUrl;
@@ -126,7 +123,7 @@ public class S3FileUploader {
             log.error("Multipart Upload 실패", e);
             amazonS3Client.abortMultipartUpload(new AbortMultipartUploadRequest(
                     bucket,
-                    fileName,
+                    savedName,
                     uploadId
             ));
             throw new RuntimeException("파일 업로드 실패", e);
@@ -151,11 +148,6 @@ public class S3FileUploader {
         } catch (Exception e) {
             log.error("[AttachmentStore][rollbackS3] S3 롤백 실패: {}", savedName, e);
         }
-    }
-
-    // 파일 이름 생성 메소드
-    private String createFileName(String originalFileName) {
-        return UUID.randomUUID().toString() + "_" + originalFileName;
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #23 

## 개요
기존에 테스트용으로 작성했던 대용량 파일 업로드 기능과, 파일 업로드 로직을 정리하려고함

## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  FileStorageService에서 private 메소드를 통해 fileUtils의 메소드를 호출하고 있었음 하나의 public 메소드안에서 private 메소드를 호출하고 또 그 안에서 다른 파일에 public 메소드를 호출하고 있는 구조라 코드의 흐름을 따라가기가 쉽지 않았음

- **to-be**(변경 후 설명을 여기에 작성)
  FileStorageService에서 private 메소드를 통해 fileUtils의 메소드를 호출하던 것을 바로 fileUtils로 호출할 수 있게함, S3 업로드를 위해 tempFile을 생성하는데 여기서 temp 파일의 경로를 사용하지 않고 uuid와 파일명을 사용하여 S3 url를 생성하도록 변경함

  - [x] FileUtils 클래스 정리 or 리펙토링
  - [x] FileStorageService 클래스 정리 or 리펙토링
