### PR TITLE
feat: article 상세보기 기능 추가

### DIFF
--- a/src/main/java/re/kr/icuh/icuhplatform/controller/FileStorageController.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/controller/FileStorageController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import re.kr.icuh.icuhplatform.dto.article.ArticleListResponse;
+import re.kr.icuh.icuhplatform.dto.article.ArticleResponse;
 import re.kr.icuh.icuhplatform.dto.article.CreateArticleRequest;
 import re.kr.icuh.icuhplatform.global.common.ApiResponse;
 import re.kr.icuh.icuhplatform.service.ArticleService;
@@ -38,6 +39,16 @@ public class FileStorageController {
 
         List<ArticleListResponse> articles = articleService.findArticles(documentType, subjectDomain, source);
         ApiResponse<List<ArticleListResponse>> response = new ApiResponse<>().success(articles);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/articles/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<ApiResponse<ArticleResponse>> getArticle(@PathVariable Long id) {
+
+        ArticleResponse article = articleService.findArticleById(id);
+        ApiResponse<ArticleResponse> response = new ApiResponse<>().success(article);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/re/kr/icuh/icuhplatform/service/ArticleService.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/service/ArticleService.java
@@ -4,9 +4,11 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.multipart.MultipartFile;
 import re.kr.icuh.icuhplatform.domain.*;
 import re.kr.icuh.icuhplatform.dto.article.ArticleListResponse;
+import re.kr.icuh.icuhplatform.dto.article.ArticleResponse;
 import re.kr.icuh.icuhplatform.dto.article.CreateArticleRequest;
 import re.kr.icuh.icuhplatform.global.exception.BusinessException;
 import re.kr.icuh.icuhplatform.global.exception.ErrorCode;
@@ -34,6 +36,7 @@ public class ArticleService {
     private final DocumentTypeRepository documentTypeRepository;
     private final SubjectDomainRepository subjectDomainRepository;
     private final JPAQueryFactory queryFactory;
+    private final RestClient.Builder builder;
 
     public void createArticle(CreateArticleRequest request, List<MultipartFile> files) {
         validateFiles(files);
@@ -109,5 +112,23 @@ public class ArticleService {
         }
 
         return articleResponses;
+    }
+
+    public ArticleResponse findArticleById(Long id) {
+
+        QArticle qArticle = QArticle.article;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (id != null) {
+            builder.and(qArticle.id.eq(id));
+        }
+
+        Article article = queryFactory
+                .selectFrom(qArticle)
+                .where(builder)
+                .fetchOne();
+
+
+        return ArticleResponse.fromEntity(article);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #31 

## 개요
게시글 상세보기 기능 추가 및 다운로드 url 리턴

## 변경 타입
- [x] 신규 기능 추가/수정

## 변경 내용
- **as-is**
  - (변경 전 설명을 여기에 작성)
  - 게시글 리스트 화면에서 상세보기 페이지가 존재하지 않았음 

- **to-be**(변경 후 설명을 여기에 작성)
  - (변경 전 설명을 여기에 작성)
  - 게시글 리스트 화면에서 상세보기 페이지가 존재하며 첨부파일이 있을 때 다운로드 가능한 url를 넘겨준다.

