### PR TITLE
feat: 게시글 리스트 응답시 문서유형, 주제영역, 출처 반환

### DIFF
--- a/src/main/java/re/kr/icuh/icuhplatform/dto/article/ArticleListResponse.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/dto/article/ArticleListResponse.java
@@ -13,7 +13,10 @@ public record ArticleListResponse(
         String authorOrganization,
         LocalDateTime updatedAt,
         Integer views,
-        List<String> extensions
+        List<String> extensions,
+        String documentType,
+        String subjectDomain,
+        String source
 ) {
     public static ArticleListResponse fromEntity(Article article) {
         return new ArticleListResponse(
@@ -25,7 +28,10 @@ public record ArticleListResponse(
                 article.getFiles().stream()
                         .filter(file -> file.getStatus() == FileEntity.FileStatus.ACTIVE)
                         .map(file -> file.getExtension().getName())
-                        .collect(Collectors.toList())
+                        .collect(Collectors.toList()),
+                article.getDocumentType().getEnName(),
+                article.getSubjectDomain().getEnName(),
+                article.getSource()
         );
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #45 

## 개요
게시글 리스트 반환시 문서유형, 주제영역, 출처 반환

## 변경 타입
- [x] 신규 기능 추가/수정

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)
