### PR TITLE
fix: 게시글 수정 요청시 임시 비밀번호 비교 로직 오류 수정

### DIFF
--- a/src/main/java/re/kr/icuh/icuhplatform/service/ArticleService.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/service/ArticleService.java
@@ -114,7 +114,7 @@ public class ArticleService {
         Article article = articleRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND));
 
-        if (article.validatePassword(request.password())) {
+        if (!article.validatePassword(request.password())) {
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #53 

## 개요
- 게시글 수정 요청 시 임시 비밀번호 비교 로직 논리 연산자 수정

## 변경 타입
- [ ] 신규 기능 추가/수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - (article.validatePassword(request.password()))

- **to-be**(변경 후 설명을 여기에 작성)
  - (!article.validatePassword(request.password()))

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.
