### PR TITLE
fix: 게시글 수정 요청 시 게시글 상태 변경 로직 수정

### DIFF
--- a/src/main/java/re/kr/icuh/icuhplatform/controller/FileStorageController.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/controller/FileStorageController.java
@@ -52,8 +52,8 @@ public class FileStorageController {
     }
 
     @PostMapping("/articles/{id}")
-    public ResponseEntity<ApiResponse<ArticleResponse>> requestArticleStatueChange(@PathVariable Long id, @RequestBody RequestStatusChange request) {
-        return ResponseEntity.ok(ApiResponse.success(articleService.requestArticleStatueChange(id, request)));
+    public ResponseEntity<ApiResponse<ArticleResponse>> requestArticleUpdate(@PathVariable Long id, @RequestBody RequestStatusChange request) {
+        return ResponseEntity.ok(ApiResponse.success(articleService.requestArticleUpdate(id, request)));
     }
 
     @PatchMapping("/articles/{id}")

--- a/src/main/java/re/kr/icuh/icuhplatform/domain/Article.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/domain/Article.java
@@ -99,6 +99,11 @@ public class Article {
         this.views++;
     }
 
+    // 상태변경
+    public void changeStatus(ArticleStatus status) {
+        this.status = status;
+    }
+
     // 파일 추가 메서드
     public void addFile(FileEntity file) {
         this.files.add(file);

--- a/src/main/java/re/kr/icuh/icuhplatform/service/ArticleService.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/service/ArticleService.java
@@ -82,9 +82,11 @@ public class ArticleService {
     }
 
     @Transactional
-    public ArticleResponse requestArticleStatueChange(Long id, RequestStatusChange request) {
+    public ArticleResponse requestArticleUpdate(Long id, RequestStatusChange request) {
         Article article = articleRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND));
+
+        article.changeStatus(ArticleStatus.UPDATED_PENDING);
 
         if (!article.validatePassword(request.password())) {
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);
@@ -92,7 +94,7 @@ public class ArticleService {
 
         ArticleStatusHistory articleStatusHistory = ArticleStatusHistory.builder()
                 .article(article)
-                .status(article.getStatus())
+                .status(ArticleStatus.UPDATED_PENDING)
                 .note(request.reason())
                 .changedBy(article.getAuthor())
                 .changedAt(LocalDateTime.now())


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #57 

## 개요
게시글 수정 요청 시 게시글 상태가 APPROVED로 설정되는 버그 

## 변경 타입
- [ ] 신규 기능 추가/수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - article.status의 상태가 APPROVED

- **to-be**(변경 후 설명을 여기에 작성)
  - article.status의 상태를 UPDATED_PENDING으로 변경

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)
