### PR TITLE
feat: 수정 요청 메소드 추가

### DIFF
--- a/src/main/java/re/kr/icuh/icuhplatform/service/ArticleService.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/service/ArticleService.java
@@ -85,21 +85,9 @@ public class ArticleService {
         Article article = articleRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND));
 
-        article.changeStatus(ArticleStatus.UPDATED_PENDING);
-
         if (!article.validatePassword(request.password())) {
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);
         }
-
-        ArticleStatusHistory articleStatusHistory = ArticleStatusHistory.builder()
-                .article(article)
-                .status(ArticleStatus.UPDATED_PENDING)
-                .note(request.reason())
-                .changedBy(article.getAuthor())
-                .changedAt(LocalDateTime.now())
-                .build();
-
-        articleStatusHistoryRepository.save(articleStatusHistory);
 
         return ArticleResponse.fromEntity(article);
     }
@@ -117,7 +105,7 @@ public class ArticleService {
         savedArticle.setPendingUpdate(request);
         savedArticle.setPendingFileUpdate(request.newFiles());
 
-        return 0L;
+        return savedArticle.getId();
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #73  

## 개요
게시글 수정 요청 시 pending_update 컬럼에 변경될 게시글의 내용을 저장하고 관리자 페이지로 수정 승인을 요청하는 기능

## 변경 타입
- [X] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - 수정용 임시 테이블을 활용하여 수정 요청 기능을 수행함

- **to-be**(변경 후 설명을 여기에 작성)
  - article 테이블 내의 json 형태의 데이터를 저장할 수 있는 pending_update 컬럼을 생성하여 수정 요청 기능을 개발함
  - [X] 수정 요청 시, status 상태 값을 APPROVED 변경하고 아직 수정전인 게시글은 노출시킨다.
  - [X] 관리자 페이지에선 status 값이 APPROVED 이면서, pending_update, pending_file_update 컬럼이 not null인 데이터를 필터링 한다.
  - [X] 관리자 페이지에서 최종적으로 게시글을 승인 시 pending_update, pending_file_update 컬럼에 내용으로 덮어쓴다.
  - [X] 게시글 수정 완료 리스트 페이지로 리다이렉트한다.

## 체크리스트
- [X] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)
