### PR TITLE
fix: 파일 업로드 예외 발생 시, 일괄 트랜잭션 적

### DIFF
--- a/src/main/java/re/kr/icuh/icuhplatform/controller/ArticleController.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/controller/ArticleController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 import re.kr.icuh.icuhplatform.dto.article.*;
+import re.kr.icuh.icuhplatform.dto.file.CreateArticleWithFilesRequest;
 import re.kr.icuh.icuhplatform.global.common.ApiResponse;
 import re.kr.icuh.icuhplatform.service.ArticleService;
 
@@ -53,5 +54,11 @@ public class ArticleController {
     public ApiResponse<Void> deleteArticle(@PathVariable Long articleId, @Valid @RequestBody DeleteArticleRequest request) {
         articleService.deleteArticle(articleId, request);
         return ApiResponse.success();
+    }
+
+    // 새로운 통합 API
+    @PostMapping("/articles-with-files")
+    public ApiResponse<CreateArticleResponse> createArticleWithFiles(@Valid @RequestBody CreateArticleWithFilesRequest request) {
+        return ApiResponse.success(articleService.createArticleWithFiles(request));
     }
 }

--- a/src/main/java/re/kr/icuh/icuhplatform/controller/FileController.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/controller/FileController.java
@@ -76,7 +76,7 @@ public class FileController {
     }
 
     @PostMapping("/complete-upload")
-    public ResponseEntity<Void> completeUpload(@RequestBody CompleteUploadRequestDto request) {
+    public ResponseEntity<CompleteFileUploadResponseDto> completeUpload(@RequestBody CompleteUploadRequestDto request) {
 
         // 클라이언트가 보낸 etag 리스트를 AWS SDK용 PartETag 리스트로 변환
         List<PartETag> partETags = request.getParts().stream()
@@ -90,12 +90,19 @@ public class FileController {
                 partETags
         );
 
-        CompleteMultipartUploadResult completeMultipartUploadResult = amazonS3Client.completeMultipartUpload(completeMultipartUploadRequest);
+        CompleteMultipartUploadResult result = amazonS3Client.completeMultipartUpload(completeMultipartUploadRequest);
         log.info("Upload complete for {}", request.getFileName());
 
-        fileStorageService.createFileMetaData(request, completeMultipartUploadResult.getLocation());
+        // 기존: 여기서 DB로 저장
+        // fileStorageService.createFileEntity(request, completeMultipartUploadResult.getLocation());
 
-        return ResponseEntity.ok().build();
+        // 변경: S3 업로드만 완료하고 메타데이터만 전달
+        return ResponseEntity.ok(new CompleteFileUploadResponseDto(
+                request.getUploadId(),
+                request.getFileName(),
+                result.getLocation(),
+                result.getETag()
+                ));
     }
 
     @PostMapping("/update-upload")

--- a/src/main/java/re/kr/icuh/icuhplatform/dto/file/CompleteFileUploadResponseDto.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/dto/file/CompleteFileUploadResponseDto.java
@@ -1,0 +1,15 @@
+package re.kr.icuh.icuhplatform.dto.file;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CompleteFileUploadResponseDto {
+    private String uploadId;
+    private String fileName;
+    private String location;
+    private String ETag;
+}

--- a/src/main/java/re/kr/icuh/icuhplatform/dto/file/CreateArticleWithFilesRequest.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/dto/file/CreateArticleWithFilesRequest.java
@@ -1,0 +1,27 @@
+package re.kr.icuh.icuhplatform.dto.file;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record CreateArticleWithFilesRequest(
+        @NotNull String title,
+        @NotNull String description,
+        @NotNull String author,
+        @NotNull String authorOrganization,
+        @NotNull String department,
+        @NotNull String tempPassword,
+        @NotNull Long documentTypeId,
+        @NotNull Long subjectDomainId,
+        @NotNull String source,
+        @NotNull List<CompletedFileUpload> completedFiles
+) {
+    public record CompletedFileUpload(
+            @NotNull String uploadId,           // /generate-upload-id에서 받은 uploadId
+            @NotNull String s3Key,              // /generate-upload-id에서 받은 s3Key
+            @NotNull String s3Location,         // /complete-upload에서 받은 location
+            @NotNull String originalFileName,   // 원본 파일명
+            @NotNull Long fileSize,             // 파일 크기 (바이트)
+            String contentType
+    ) {}
+}

--- a/src/main/java/re/kr/icuh/icuhplatform/service/ArticleService.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/service/ArticleService.java
@@ -7,17 +7,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import re.kr.icuh.icuhplatform.domain.Article;
-import re.kr.icuh.icuhplatform.domain.ArticleStatus;
-import re.kr.icuh.icuhplatform.domain.DocumentType;
-import re.kr.icuh.icuhplatform.domain.SubjectDomain;
+import re.kr.icuh.icuhplatform.domain.*;
 import re.kr.icuh.icuhplatform.dto.article.*;
+import re.kr.icuh.icuhplatform.dto.file.CreateArticleWithFilesRequest;
 import re.kr.icuh.icuhplatform.global.exception.BusinessException;
 import re.kr.icuh.icuhplatform.global.exception.ErrorCode;
-import re.kr.icuh.icuhplatform.repository.ArticleQueryRepository;
-import re.kr.icuh.icuhplatform.repository.ArticleRepository;
-import re.kr.icuh.icuhplatform.repository.DocumentTypeRepository;
-import re.kr.icuh.icuhplatform.repository.SubjectDomainRepository;
+import re.kr.icuh.icuhplatform.global.util.FileUtils;
+import re.kr.icuh.icuhplatform.repository.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -27,9 +23,11 @@ import java.util.stream.Collectors;
 public class ArticleService {
 
     private final ArticleRepository articleRepository;
+    private final FileRepository fileRepository;
     private final DocumentTypeRepository documentTypeRepository;
     private final SubjectDomainRepository subjectDomainRepository;
     private final ArticleQueryRepository articleQueryRepository;
+    private final FileUtils fileUtils;
 
     @Transactional(readOnly = true)
     public Page<ArticleListResponse> findArticles(ArticleRequest request, Pageable pageable) {
@@ -45,6 +43,7 @@ public class ArticleService {
 
     @Transactional
     public CreateArticleResponse createArticle(CreateArticleRequest request) {
+        // TODO: 게시글이 생성되다가 실패하는 경우 게시글 생성 행위 자체가 rollback이 되어야한다.
         DocumentType documentType = validateDocumentType(request.documentTypeId());
         SubjectDomain subjectDomain = validateSubjectDomain(request.subjectDomainId());
 
@@ -98,6 +97,53 @@ public class ArticleService {
         validatePassword(savedArticle, request.password());
 
         savedArticle.delete();
+    }
+
+    @Transactional
+    public CreateArticleResponse createArticleWithFiles(CreateArticleWithFilesRequest request) {
+        try {
+            // 1. 게시글 저장
+            DocumentType documentType = validateDocumentType(request.documentTypeId());
+            SubjectDomain subjectDomain = validateSubjectDomain(request.subjectDomainId());
+
+            Article article = Article.builder()
+                    .title(request.title())
+                    .description(request.description())
+                    .author(request.author())
+                    .authorOrganization(request.authorOrganization())
+                    .department(request.department())
+                    .tempPassword(request.tempPassword())
+                    .views(0)
+                    .status(ArticleStatus.PENDING)
+                    .documentType(documentType)
+                    .subjectDomain(subjectDomain)
+                    .source(request.source())
+                    .isDeleted(false)
+                    .deletedAt(null)
+                    .build();
+
+
+            // 2. 파일 메타데이터 저장 (게시글 ID와 연결)
+            List<FileEntity> files = request.completedFiles().stream()
+                    .map(fileInfo -> FileEntity.builder()
+                                    .article(article)
+                                    .originalFilename(fileInfo.originalFileName())
+                                    .storedFilename(fileInfo.originalFileName())
+                                    .filePath(fileInfo.s3Location())
+                                    .fileSize(fileInfo.fileSize())
+                                    .extension(fileUtils.extractExtensionName(fileInfo.originalFileName()))
+                                    .status(FileStatus.PENDING)
+                                    .build()
+                            )
+                    .collect(Collectors.toList());
+
+            fileRepository.saveAll(files);
+
+            return null;
+        } catch (Exception e) {
+            // 실패 시: 업로드된 S3 파일 삭제 + 에러 응답
+            throw new BusinessException(ErrorCode.FILE_SIZE_EXCEEDED);
+        }
     }
 
     private static void validatePassword(Article article, String password) {

--- a/src/main/java/re/kr/icuh/icuhplatform/service/ArticleUploadFacade.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/service/ArticleUploadFacade.java
@@ -1,0 +1,21 @@
+package re.kr.icuh.icuhplatform.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import re.kr.icuh.icuhplatform.dto.article.CreateArticleRequest;
+import re.kr.icuh.icuhplatform.dto.file.CompleteUploadRequestDto;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleUploadFacade {
+
+    private final ArticleService articleService;
+    private final FileService fileService;
+
+    @Transactional
+    public void createFullArticle(CreateArticleRequest request, CompleteUploadRequestDto fileRequest, String location) {
+        articleService.createArticle(request);
+        fileService.createFileEntity(fileRequest, location);
+    }
+}

--- a/src/main/java/re/kr/icuh/icuhplatform/service/FileService.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/service/FileService.java
@@ -25,7 +25,7 @@ public class FileService {
     private final ArticleRepository articleRepository;
 
     @Transactional
-    public void createFileMetaData(CompleteUploadRequestDto request, String location) {
+    public void createFileEntity(CompleteUploadRequestDto request, String location) {
         Article savedArticle = articleRepository.findById(request.getArticleId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND));
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #79 

## 개요
- 파일 업로드 예외 발생 시, 게시글만 등록되는 이슈

## 변경 타입
- [ ] 신규 기능 추가/수정
- [X] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - 파일 업로드 예외 발생 시, 게시글만 등록되는 이슈

- **to-be**(변경 후 설명을 여기에 작성)
  - 파일 업로드 예외 발생 시, 게시글도 등록되지 않도록 수정
