### PR TITLE
Feat/#87/create category api

### DIFF
--- a/src/main/java/re/kr/icuh/icuhplatform/controller/CategoryController.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/controller/CategoryController.java
@@ -1,0 +1,21 @@
+package re.kr.icuh.icuhplatform.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import re.kr.icuh.icuhplatform.dto.CategoryResponse;
+import re.kr.icuh.icuhplatform.service.CategoryService;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping("/article-categories")
+    public CategoryResponse getCategory() {
+        return categoryService.getCategories();
+    }
+}

--- a/src/main/java/re/kr/icuh/icuhplatform/dto/CategoryResponse.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/dto/CategoryResponse.java
@@ -1,0 +1,12 @@
+package re.kr.icuh.icuhplatform.dto;
+
+import java.util.List;
+
+public record CategoryResponse(
+    List<DocumentTypesResponse> documentTypesResponse,
+    List<SubjectDomainsResponse> subjectDomainsResponses
+) {
+    public static CategoryResponse of(List<DocumentTypesResponse> documentTypesResponses, List<SubjectDomainsResponse> subjectDomainsResponses) {
+        return new CategoryResponse(documentTypesResponses, subjectDomainsResponses);
+    }
+}

--- a/src/main/java/re/kr/icuh/icuhplatform/dto/DocumentTypesResponse.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/dto/DocumentTypesResponse.java
@@ -1,0 +1,17 @@
+package re.kr.icuh.icuhplatform.dto;
+
+import re.kr.icuh.icuhplatform.domain.DocumentType;
+
+public record DocumentTypesResponse(
+    String code,
+    String name,
+    String enName
+) {
+    public static DocumentTypesResponse from(DocumentType documentType) {
+        return new DocumentTypesResponse(
+                documentType.getCode(),
+                documentType.getName(),
+                documentType.getEnName()
+        );
+    }
+}

--- a/src/main/java/re/kr/icuh/icuhplatform/dto/SubjectDomainsResponse.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/dto/SubjectDomainsResponse.java
@@ -1,0 +1,17 @@
+package re.kr.icuh.icuhplatform.dto;
+
+import re.kr.icuh.icuhplatform.domain.SubjectDomain;
+
+public record SubjectDomainsResponse(
+    String code,
+    String name,
+    String enName
+) {
+    public static SubjectDomainsResponse from(SubjectDomain subjectDomain) {
+        return new SubjectDomainsResponse(
+                subjectDomain.getCode(),
+                subjectDomain.getName(),
+                subjectDomain.getEnName()
+        );
+    }
+}

--- a/src/main/java/re/kr/icuh/icuhplatform/dto/article/UpdateArticleRequest.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/dto/article/UpdateArticleRequest.java
@@ -11,10 +11,10 @@ public record UpdateArticleRequest(
         @NotNull String authorOrganization,
         @NotNull String department,
         @NotNull String tempPassword,
-        @NotNull Long documentTypeId,
-        @NotNull Long subjectDomainId,
+        @NotNull String documentTypeCode,
+        @NotNull String subjectDomainCode,
         @NotNull String source,
-        List<NewFileRequest>newFiles
+        List<NewFileRequest> newFiles
 ) {
     public record NewFileRequest(
             String originalFileName,

--- a/src/main/java/re/kr/icuh/icuhplatform/repository/DocumentTypeRepository.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/repository/DocumentTypeRepository.java
@@ -4,9 +4,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import re.kr.icuh.icuhplatform.domain.DocumentType;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface DocumentTypeRepository extends JpaRepository<DocumentType, Long> {
     Optional<DocumentType> findByCode(String code);
+
+    List<DocumentType> findByStatus(String status);
 }

--- a/src/main/java/re/kr/icuh/icuhplatform/repository/SubjectDomainRepository.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/repository/SubjectDomainRepository.java
@@ -4,9 +4,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import re.kr.icuh.icuhplatform.domain.SubjectDomain;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface SubjectDomainRepository extends JpaRepository<SubjectDomain, Long> {
     Optional<SubjectDomain> findByCode(String code);
+
+    List<SubjectDomain> findByStatus(String status);
 }

--- a/src/main/java/re/kr/icuh/icuhplatform/service/CategoryService.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/service/CategoryService.java
@@ -1,0 +1,33 @@
+package re.kr.icuh.icuhplatform.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import re.kr.icuh.icuhplatform.dto.CategoryResponse;
+import re.kr.icuh.icuhplatform.dto.DocumentTypesResponse;
+import re.kr.icuh.icuhplatform.dto.SubjectDomainsResponse;
+import re.kr.icuh.icuhplatform.repository.DocumentTypeRepository;
+import re.kr.icuh.icuhplatform.repository.SubjectDomainRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final DocumentTypeRepository documentTypeRepository;
+    private final SubjectDomainRepository subjectDomainRepository;
+
+    public CategoryResponse getCategories() {
+        List<DocumentTypesResponse> documentTypesResponses = documentTypeRepository.findByStatus("ACTIVE")
+                .stream()
+                .map(DocumentTypesResponse::from)
+                .toList();
+
+        List<SubjectDomainsResponse> subjectDomainsResponses = subjectDomainRepository.findByStatus("ACTIVE")
+                .stream()
+                .map(SubjectDomainsResponse::from)
+                .toList();
+
+        return new CategoryResponse(documentTypesResponses, subjectDomainsResponses);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #87 

## 개요
관리자가 직접 카테고리를 생성하고 수정하게 되는 역할을 담당하게 되면서 프론트에서 하드코딩되어 있는 카테고리를 수정

## 변경 타입
- [X] 신규 기능 추가/수정
- [ ] 버그 수정
- [X] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **to-be**(변경 후 설명을 여기에 작성)

  - [x] 응답 스펙(DTO) 개발
  - [x] Repository 조회 메소드 개발
  - [x] Service 레이어 구성
  - [x] Controller 레이어 구성

## 체크리스트
- [ ] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)
