### PR TITLE
refactor: n + 1 문제가 되는 dto 구간 수정

### DIFF
--- a/src/main/java/re/kr/icuh/icuhplatform/article/dto/response/ArticleListResponse.java
+++ b/src/main/java/re/kr/icuh/icuhplatform/article/dto/response/ArticleListResponse.java
@@ -3,8 +3,6 @@ package re.kr.icuh.icuhplatform.article.dto.response;
 import re.kr.icuh.icuhplatform.article.domain.Article;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public record ArticleListResponse(
         Long id,
@@ -12,7 +10,6 @@ public record ArticleListResponse(
         String authorOrganization,
         LocalDateTime updatedAt,
         Integer views,
-        List<String> extensions,
         String documentType,
         String subjectDomain,
         String source
@@ -24,9 +21,6 @@ public record ArticleListResponse(
                 article.getAuthorOrganization(),
                 article.getUpdatedAt(),
                 article.getViews(),
-                article.getFiles().stream()
-                        .map(file -> file.getExtension())
-                        .collect(Collectors.toList()),
                 article.getDocumentType().getCode(),
                 article.getSubjectDomain().getCode(),
                 article.getSource()


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #91 

## 개요
리스트 페이지에서 n + 1 문제가 발생되어, 추적해본 결과 리스트 페이지에서 연관관계에 있는 데이터를 컬렉션으로 내려주고 있었음

## 변경 타입
- [ ] 신규 기능 추가/수정
- [X] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - 리스트 페이지에서 컬렉션을 내리는 설계

- **to-be**(변경 후 설명을 여기에 작성)
  - 리스트 페이지에서 컬렉션을 굳이 내려보내지 않기로 설계로 변경